### PR TITLE
fix to workspace/current endpoint

### DIFF
--- a/Extensions/Modules/NodesModule.cs
+++ b/Extensions/Modules/NodesModule.cs
@@ -12,7 +12,7 @@ namespace DynamoServer.Server
     {
         public NodesModule() : base("/Nodes")
         {
-            Get["/Get"] = GetNodes;
+            Get["/"] = GetNodes;
             Get["/Clear"] = Clear;
             Get["/Add/{nodename}"] = AddNode;
         }

--- a/Extensions/Modules/PackagesModule.cs
+++ b/Extensions/Modules/PackagesModule.cs
@@ -13,7 +13,7 @@ namespace DynamoServer.Server
     {
         public PackagesModule() : base("/Packages")
         {
-            Get["/Get"] = GetPackages;
+            Get["/"] = GetPackages;
             Get["/Install/{packagename}"] = InstallPackage;
             Get["/Remove/{packagename}"] = RemovePackage;
         }
@@ -30,7 +30,7 @@ namespace DynamoServer.Server
             int packageCountBefore = 0, packageCountAfter = 0;
             IEnumerable<IExtension> packages;
 
-            List<string> uniqueLibs = new List<string>();
+            HashSet<string> uniqueLibs = new List<string>();
 
             ServerViewExtension.RunInContext(() =>
             {

--- a/Extensions/Modules/WorkspaceModule.cs
+++ b/Extensions/Modules/WorkspaceModule.cs
@@ -3,7 +3,6 @@ using DynamoServer.Extensions;
 using Nancy;
 using System;
 using System.IO;
-using System.Windows;
 
 namespace DynamoServer.Server
 {
@@ -63,7 +62,7 @@ namespace DynamoServer.Server
             ServerViewExtension.RunInContext(() =>
             {
                 filePath = ServerViewExtension.viewLoadedParams.CurrentWorkspaceModel.FileName;
-                if (filePath == "")
+                if (string.IsNullOrWhiteSpace(filePath))
                 {
                     filePath = "File has not been saved yet";
                     fileName = "Home - Default Name";
@@ -119,9 +118,7 @@ namespace DynamoServer.Server
                     ServerViewExtension.DynamoLogger.Log("Saving " + file);
                     ServerViewExtension.dynamoViewModel.SaveCommand.Execute(null);
                     result = "Successfully Saved file : " + file;
-                    MessageBox.Show("File Saved");
                 }
-
             }
             );
 

--- a/Server/Views/start.html
+++ b/Server/Views/start.html
@@ -282,7 +282,7 @@
                                     <article class="message is-primary">
                                         <div class="message-body">
                                             URL</br>
-                                            <em class="has-text-grey-light">http://localhost:1234/</em><strong>Nodes/Get</strong>
+                                            <em class="has-text-grey-light">http://localhost:1234/</em><strong>Nodes/</strong>
                                         </div>
                                     </article>
                                 </div>
@@ -365,7 +365,7 @@
                                     <article class="message is-primary">
                                         <div class="message-body">
                                             URL</br>
-                                            <em class="has-text-grey-light">http://localhost:1234/</em><strong>Packages/Get</strong>
+                                            <em class="has-text-grey-light">http://localhost:1234/</em><strong>Packages/</strong>
                                         </div>
                                     </article>
                                 </div>


### PR DESCRIPTION
## Purpose

This PR closes issue #10 

### Current behaviour
Currently retrieving the current workspace filename will return a blank if the file hasn't been saved prior. 

### New behaviour
Puts some default values in if the filepath retuns an empty string

### Implementation
n/a

### Known limitations & dependencies
n/a


## Declarations

Check these if you believe they are true

#### Codebase
- [/] The code base is in a better state after this PR
- [/] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards) and ready for inclusion with release notes.
- [ ] User facing strings, if any, are extracted into `*.resx` files

#### Testing
- [/] The level of testing this PR includes is appropriate
- [/] The solution has been compiled, loaded and tested in current Dynamo version (1.3)
- [ ] All tests pass using the self-service CI (if present).

#### Changes
- [ ] Snapshot of UI changes, if any.
- [ ] Version change follows [Semantic Versioning](http://semver.org/) and is updated in the assembly DLL version. 

## Reviewers

Reviewer 1 
@radumg 
